### PR TITLE
Remove SYSTEM_VERSION_COMPAT setting.

### DIFF
--- a/.github/workflows/wheel.yaml
+++ b/.github/workflows/wheel.yaml
@@ -36,7 +36,6 @@ jobs:
           CIBW_TEST_REQUIRES: pytest
           MACOSX_DEPLOYMENT_TARGET: 11.00
           CIBW_BUILD_VERBOSITY: 2
-          SYSTEM_VERSION_COMPAT: 1
 
       - uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
To ensure wheels are built correctly.

To install the wheel on python built with older Mac SDK (e.g. python installed via conda), use
```sh
SYSTEM_VERSION_COMPAT=0 pip install lagrange-open
```