### PR TITLE
v6.33.0 fix

### DIFF
--- a/.github/workflows/wheel.yaml
+++ b/.github/workflows/wheel.yaml
@@ -47,7 +47,7 @@ jobs:
           CIBW_REPAIR_WHEEL_COMMAND_LINUX: ""
           CIBW_TEST_COMMAND: "pytest -s --pdb {project}/modules"
           CIBW_TEST_REQUIRES: pytest
-          MACOSX_DEPLOYMENT_TARGET: 11.00
+          MACOSX_DEPLOYMENT_TARGET: 13.00
           CIBW_BUILD_VERBOSITY: 2
 
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/wheel.yaml
+++ b/.github/workflows/wheel.yaml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+      - qnzhou/v6.33.0
   release:
     types:
       - published

--- a/.github/workflows/wheel.yaml
+++ b/.github/workflows/wheel.yaml
@@ -4,7 +4,6 @@ on:
   pull_request:
     branches:
       - main
-      - qnzhou/v6.33.0
   release:
     types:
       - published

--- a/modules/core/python/src/bind_surface_mesh.h
+++ b/modules/core/python/src/bind_surface_mesh.h
@@ -827,7 +827,7 @@ void bind_surface_mesh(nanobind::module_& m)
                 make_shared_span(owner, values.data(), values.size()),
                 static_cast<Index>(num_facets),
                 static_cast<Index>(vertex_per_facet));
-            auto& attr = self.template ref_attribute<Scalar>(id);
+            auto& attr = self.template ref_attribute<Index>(id);
             attr.set_growth_policy(AttributeGrowthPolicy::WarnAndCopy);
         },
         "Facets of the mesh.");
@@ -865,7 +865,7 @@ void bind_surface_mesh(nanobind::module_& m)
                 make_shared_span(owner, values.data(), values.size()),
                 num_facets,
                 vertex_per_facet);
-            auto& attr = self.template ref_attribute<Scalar>(id);
+            auto& attr = self.template ref_attribute<Index>(id);
             attr.set_growth_policy(AttributeGrowthPolicy::WarnAndCopy);
             return id;
         },
@@ -899,7 +899,7 @@ void bind_surface_mesh(nanobind::module_& m)
                 num_facets,
                 make_shared_span(facets_owner, facets_data.data(), facets_data.size()),
                 num_corners);
-            auto& attr = self.template ref_attribute<Scalar>(id);
+            auto& attr = self.template ref_attribute<Index>(id);
             attr.set_growth_policy(AttributeGrowthPolicy::WarnAndCopy);
             return id;
         },

--- a/modules/filtering/CMakeLists.txt
+++ b/modules/filtering/CMakeLists.txt
@@ -28,8 +28,7 @@ if(NOT EMSCRIPTEN)
             # Hold off on using MKL for now to avoid bloating the package size.
             # include(blas) # Accelerate on arm64 macOS, MKL on other platforms
             # target_compile_definitions(lagrange_filtering PRIVATE LA_SOLVER_MKL)
-            add_library(BLAS IMPORTED INTERFACE GLOBAL)
-            add_library(BLAS::BLAS ALIAS BLAS)
+            add_library(BLAS::BLAS INTERFACE IMPORTED GLOBAL)
         endif()
     else()
         include(blas) # Accelerate on arm64 macOS, MKL on other platforms

--- a/modules/filtering/CMakeLists.txt
+++ b/modules/filtering/CMakeLists.txt
@@ -28,7 +28,7 @@ if(NOT EMSCRIPTEN)
             # Hold off on using MKL for now to avoid bloating the package size.
             # include(blas) # Accelerate on arm64 macOS, MKL on other platforms
             # target_compile_definitions(lagrange_filtering PRIVATE LA_SOLVER_MKL)
-            add_library(BLAS GLOBAL IMPORTED INTERFACE)
+            add_library(BLAS IMPORTED INTERFACE GLOBAL)
             add_library(BLAS::BLAS ALIAS BLAS)
         endif()
     else()

--- a/modules/filtering/CMakeLists.txt
+++ b/modules/filtering/CMakeLists.txt
@@ -28,7 +28,8 @@ if(NOT EMSCRIPTEN)
             # Hold off on using MKL for now to avoid bloating the package size.
             # include(blas) # Accelerate on arm64 macOS, MKL on other platforms
             # target_compile_definitions(lagrange_filtering PRIVATE LA_SOLVER_MKL)
-            add_library(BLAS::BLAS GLOBAL IMPORTED INTERFACE)
+            add_library(BLAS GLOBAL IMPORTED INTERFACE)
+            add_library(BLAS::BLAS ALIAS BLAS)
         endif()
     else()
         include(blas) # Accelerate on arm64 macOS, MKL on other platforms


### PR DESCRIPTION
Summary:
* Avoid CMake target name error
* Update `MACOSX_DEPLOYMENT_TARGET` to 13.0 when building wheels
* Fix the bug on using the wrong type with `dynamic_cast` (Thanks Windows builder)