### PR TITLE
Fix missing cstdint include

### DIFF
--- a/modules/core/src/mapbox/earcut.h
+++ b/modules/core/src/mapbox/earcut.h
@@ -10,6 +10,7 @@
 #include <cassert>
 #include <cmath>
 #include <cstddef>
+#include <cstdint>
 #include <limits>
 #include <memory>
 #include <utility>


### PR DESCRIPTION
## Description

Starting from gcc 13, the csdtint header is less used in stdlib. See this [official doc](https://gcc.gnu.org/gcc-13/porting_to.html) for detail. And because of that uint32_t is not defined. 

This fix add the missing #include <cstdint>.
