### PR TITLE
Bind bvh UVOverlapResult via nanobind_namedtuple

### DIFF
--- a/cmake/recipes/external/nanobind_namedtuple.cmake
+++ b/cmake/recipes/external/nanobind_namedtuple.cmake
@@ -25,7 +25,7 @@ include(CPM)
 CPMAddPackage(
     NAME nanobind_namedtuple
     GITHUB_REPOSITORY jdumas/nanobind_namedtuple
-    GIT_TAG 5eea9b5497c031ef556a250b04d47b68e54395c1
+    GIT_TAG bfb9d8a58f4e4cf64a0751efaa947746af01573b
 )
 
 set_target_properties(nanobind_namedtuple PROPERTIES FOLDER third_party)

--- a/cmake/recipes/external/nanobind_namedtuple.cmake
+++ b/cmake/recipes/external/nanobind_namedtuple.cmake
@@ -15,24 +15,17 @@ endif()
 
 message(STATUS "Third-party (external): creating target 'nanobind_namedtuple::nanobind_namedtuple'")
 
+# Provide Python and nanobind before adding the package: the upstream CMakeLists.txt skips its own
+# find_package(Python) when Python::Module exists, and skips nanobind discovery (which probes the
+# interpreter via `python -m nanobind`) when nanobind_add_module is available.
+include(python)
+include(nanobind)
+
 include(CPM)
 CPMAddPackage(
     NAME nanobind_namedtuple
     GITHUB_REPOSITORY jdumas/nanobind_namedtuple
     GIT_TAG 5eea9b5497c031ef556a250b04d47b68e54395c1
-    DOWNLOAD_ONLY ON
 )
-
-# The upstream CMakeLists.txt runs its own find_package(Python)/find_package(nanobind), which is
-# redundant within Lagrange's build (nanobind is already fetched via CPM). Since the library is
-# header-only, we declare the interface target manually instead.
-add_library(nanobind_namedtuple INTERFACE)
-add_library(nanobind_namedtuple::nanobind_namedtuple ALIAS nanobind_namedtuple)
-
-target_include_directories(nanobind_namedtuple INTERFACE
-    $<BUILD_INTERFACE:${nanobind_namedtuple_SOURCE_DIR}/include>
-)
-
-target_compile_features(nanobind_namedtuple INTERFACE cxx_std_17)
 
 set_target_properties(nanobind_namedtuple PROPERTIES FOLDER third_party)

--- a/cmake/recipes/external/nanobind_namedtuple.cmake
+++ b/cmake/recipes/external/nanobind_namedtuple.cmake
@@ -25,7 +25,7 @@ include(CPM)
 CPMAddPackage(
     NAME nanobind_namedtuple
     GITHUB_REPOSITORY jdumas/nanobind_namedtuple
-    GIT_TAG 906b5bd02968e92d0f08d6259250dd395e8ef3d7
+    GIT_TAG ec5f32323e309072fe5a47306d34d4f7fa6ddbea
 )
 
 set_target_properties(nanobind_namedtuple PROPERTIES FOLDER third_party)

--- a/cmake/recipes/external/nanobind_namedtuple.cmake
+++ b/cmake/recipes/external/nanobind_namedtuple.cmake
@@ -19,7 +19,7 @@ include(CPM)
 CPMAddPackage(
     NAME nanobind_namedtuple
     GITHUB_REPOSITORY jdumas/nanobind_namedtuple
-    GIT_TAG 38daf55e8100c903e511d422566362befd495104
+    GIT_TAG 5eea9b5497c031ef556a250b04d47b68e54395c1
     DOWNLOAD_ONLY ON
 )
 

--- a/cmake/recipes/external/nanobind_namedtuple.cmake
+++ b/cmake/recipes/external/nanobind_namedtuple.cmake
@@ -1,0 +1,38 @@
+#
+# Copyright 2026 Adobe. All rights reserved.
+# This file is licensed to you under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License. You may obtain a copy
+# of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+# OF ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+#
+if(TARGET nanobind_namedtuple::nanobind_namedtuple)
+    return()
+endif()
+
+message(STATUS "Third-party (external): creating target 'nanobind_namedtuple::nanobind_namedtuple'")
+
+include(CPM)
+CPMAddPackage(
+    NAME nanobind_namedtuple
+    GITHUB_REPOSITORY jdumas/nanobind_namedtuple
+    GIT_TAG 38daf55e8100c903e511d422566362befd495104
+    DOWNLOAD_ONLY ON
+)
+
+# The upstream CMakeLists.txt runs its own find_package(Python)/find_package(nanobind), which is
+# redundant within Lagrange's build (nanobind is already fetched via CPM). Since the library is
+# header-only, we declare the interface target manually instead.
+add_library(nanobind_namedtuple INTERFACE)
+add_library(nanobind_namedtuple::nanobind_namedtuple ALIAS nanobind_namedtuple)
+
+target_include_directories(nanobind_namedtuple INTERFACE
+    $<BUILD_INTERFACE:${nanobind_namedtuple_SOURCE_DIR}/include>
+)
+
+target_compile_features(nanobind_namedtuple INTERFACE cxx_std_17)
+
+set_target_properties(nanobind_namedtuple PROPERTIES FOLDER third_party)

--- a/cmake/recipes/external/nanobind_namedtuple.cmake
+++ b/cmake/recipes/external/nanobind_namedtuple.cmake
@@ -25,7 +25,7 @@ include(CPM)
 CPMAddPackage(
     NAME nanobind_namedtuple
     GITHUB_REPOSITORY jdumas/nanobind_namedtuple
-    GIT_TAG bfb9d8a58f4e4cf64a0751efaa947746af01573b
+    GIT_TAG 906b5bd02968e92d0f08d6259250dd395e8ef3d7
 )
 
 set_target_properties(nanobind_namedtuple PROPERTIES FOLDER third_party)

--- a/cmake/recipes/external/nanobind_namedtuple.cmake
+++ b/cmake/recipes/external/nanobind_namedtuple.cmake
@@ -25,7 +25,7 @@ include(CPM)
 CPMAddPackage(
     NAME nanobind_namedtuple
     GITHUB_REPOSITORY jdumas/nanobind_namedtuple
-    GIT_TAG ec5f32323e309072fe5a47306d34d4f7fa6ddbea
+    GIT_TAG 84243680d678a6a8b54f88c7df5c713d9bec46d1
 )
 
 set_target_properties(nanobind_namedtuple PROPERTIES FOLDER third_party)

--- a/modules/bvh/python/CMakeLists.txt
+++ b/modules/bvh/python/CMakeLists.txt
@@ -10,3 +10,6 @@
 # governing permissions and limitations under the License.
 #
 lagrange_add_python_binding()
+
+lagrange_find_package(nanobind_namedtuple REQUIRED)
+target_link_libraries(lagrange_python PRIVATE nanobind_namedtuple::nanobind_namedtuple)

--- a/modules/bvh/python/src/bvh.cpp
+++ b/modules/bvh/python/src/bvh.cpp
@@ -32,8 +32,6 @@ using namespace nb::literals;
 // single type name token, hence the alias for the template instantiation.
 using UVOverlapResult = lagrange::bvh::UVOverlapResult<double, uint32_t>;
 
-// clang-format off
-#include <lagrange/utils/warnoff.h>
 NB_NAMED_TUPLE(
     UVOverlapResult,
     "UVOverlapResult",
@@ -41,8 +39,6 @@ NB_NAMED_TUPLE(
     NB_NT_FIELD(overlap_area),
     NB_NT_FIELD(overlapping_pairs),
     NB_NT_FIELD(overlap_coloring_id))
-#include <lagrange/utils/warnon.h>
-// clang-format on
 
 namespace lagrange::python {
 

--- a/modules/bvh/python/src/bvh.cpp
+++ b/modules/bvh/python/src/bvh.cpp
@@ -34,11 +34,10 @@ using UVOverlapResult = lagrange::bvh::UVOverlapResult<double, uint32_t>;
 
 NB_NAMED_TUPLE(
     UVOverlapResult,
-    "UVOverlapResult",
-    NB_NT_FIELD(has_overlap),
-    NB_NT_FIELD(overlap_area),
-    NB_NT_FIELD(overlapping_pairs),
-    NB_NT_FIELD(overlap_coloring_id))
+    has_overlap,
+    overlap_area,
+    overlapping_pairs,
+    overlap_coloring_id)
 
 namespace lagrange::python {
 

--- a/modules/bvh/python/src/bvh.cpp
+++ b/modules/bvh/python/src/bvh.cpp
@@ -20,19 +20,31 @@
 #include <lagrange/python/binding.h>
 #include <lagrange/python/bvh.h>
 #include <lagrange/python/eigen_utils.h>
-#include <lagrange/python/utils/StubType.h>
+
+#include <nanobind_namedtuple/named_tuple.h>
 
 #include "PyEdgeAABBTree.h"
 
 namespace nb = nanobind;
 using namespace nb::literals;
 
-namespace lagrange::python {
+// Expose lagrange::bvh::UVOverlapResult to Python as a collections.namedtuple. The macro takes a
+// single type name token, hence the alias for the template instantiation.
+using UVOverlapResult = lagrange::bvh::UVOverlapResult<double, uint32_t>;
 
-// Renders the dynamically-built `UVOverlapResult` NamedTuple (a runtime nb::object)
-// with the right stub type. TODO: retire once nanobind supports NamedTuple directly.
-LA_STUB_HINT(UVOverlapResultHint, "UVOverlapResult");
-using UVOverlapResultObject = StubType<nb::object, UVOverlapResultHint>;
+// clang-format off
+#include <lagrange/utils/warnoff.h>
+NB_NAMED_TUPLE(
+    UVOverlapResult,
+    "UVOverlapResult",
+    NB_NT_FIELD(has_overlap),
+    NB_NT_FIELD(overlap_area),
+    NB_NT_FIELD(overlapping_pairs),
+    NB_NT_FIELD(overlap_coloring_id))
+#include <lagrange/utils/warnon.h>
+// clang-format on
+
+namespace lagrange::python {
 
 void populate_bvh_module(nb::module_& m)
 {
@@ -491,30 +503,18 @@ Both meshes must have the same spatial dimension and must be triangle meshes.
             "Zomorodian-Edelsbrunner HYBRID algorithm (recursive divide-and-conquer).");
 
     // UV overlap result (Python NamedTuple)
-    // Note: No direct nanobind support for NamedTuple yet, see:
-    // https://github.com/wjakob/nanobind/discussions/1279
-    nb::object typing = nb::module_::import_("typing");
-    nb::object builtins = nb::module_::import_("builtins");
-    nb::object UVOverlapResult = typing.attr("NamedTuple")(
-        "UVOverlapResult",
-        nb::make_tuple(
-            nb::make_tuple("has_overlap", builtins.attr("bool")),
-            nb::make_tuple("overlap_area", typing.attr("Optional")[builtins.attr("float")]),
-            nb::make_tuple("overlapping_pairs", builtins.attr("list")),
-            nb::make_tuple("overlap_coloring_id", builtins.attr("int"))));
-    m.attr("UVOverlapResult") = UVOverlapResult;
+    nbnt::bind_namedtuple<UVOverlapResult>(m);
 
     // compute_uv_overlap function
     m.def(
         "compute_uv_overlap",
-        [UVOverlapResult](
-            MeshType& mesh,
-            std::string uv_attribute_name,
-            bool compute_overlap_area,
-            bool compute_overlap_coloring,
-            std::string overlap_coloring_attribute_name,
-            bool compute_overlapping_pairs,
-            bvh::UVOverlapMethod method) -> UVOverlapResultObject {
+        [](MeshType& mesh,
+           std::string uv_attribute_name,
+           bool compute_overlap_area,
+           bool compute_overlap_coloring,
+           std::string overlap_coloring_attribute_name,
+           bool compute_overlapping_pairs,
+           bvh::UVOverlapMethod method) {
             bvh::UVOverlapOptions opts;
             opts.uv_attribute_name = std::move(uv_attribute_name);
             opts.compute_overlap_area = compute_overlap_area;
@@ -522,22 +522,7 @@ Both meshes must have the same spatial dimension and must be triangle meshes.
             opts.overlap_coloring_attribute_name = std::move(overlap_coloring_attribute_name);
             opts.compute_overlapping_pairs = compute_overlapping_pairs;
             opts.method = method;
-            auto result = bvh::compute_uv_overlap(mesh, opts);
-
-            nb::object area = result.overlap_area.has_value()
-                                  ? nb::cast(result.overlap_area.value())
-                                  : nb::none();
-
-            nb::list pairs;
-            for (auto& [i, j] : result.overlapping_pairs) {
-                pairs.append(nb::make_tuple(i, j));
-            }
-
-            return UVOverlapResultObject{UVOverlapResult(
-                nb::cast(result.has_overlap),
-                area,
-                pairs,
-                nb::cast(result.overlap_coloring_id))};
+            return bvh::compute_uv_overlap(mesh, opts);
         },
         "mesh"_a,
         "uv_attribute_name"_a = bvh::UVOverlapOptions{}.uv_attribute_name,

--- a/modules/python/CMakeLists.txt
+++ b/modules/python/CMakeLists.txt
@@ -231,26 +231,21 @@ function(lagrange_generate_python_binding_module)
         # single shared file is safe to pass to every module's stubgen invocation.
         set(pattern_file_args "")
         if(TARGET nanobind_namedtuple)
-            get_target_property(nbnt_source_dir nanobind_namedtuple SOURCE_DIR)
             set(pattern_file ${CMAKE_CURRENT_BINARY_DIR}/nanobind_namedtuple.pat)
-            set(pattern_module_flags "")
+            set(pattern_modules "")
             foreach(module_name IN ITEMS ${active_modules})
                 get_target_property(python_name lagrange_python LAGRANGE_PYTHON_NAME_${module_name})
                 if(NOT python_name)
                     set(python_name ${module_name})
                 endif()
-                list(APPEND pattern_module_flags -m lagrange.${python_name})
+                list(APPEND pattern_modules lagrange.${python_name})
             endforeach()
-            list(JOIN pattern_module_flags " " pattern_module_flags)
-            install(CODE "
-                message(STATUS \"Generating nanobind_namedtuple pattern file: ${pattern_file}\")
-                execute_process(
-                    COMMAND \"${CMAKE_COMMAND}\" -E env \"PYTHONPATH=${nbnt_source_dir}/stubgen\"
-                        \"${Python_EXECUTABLE}\" -m nanobind_namedtuple_stubgen
-                        -i \"${SKBUILD_PLATLIB_DIR}/lagrange/\" ${pattern_module_flags} -o \"${pattern_file}\"
-                    COMMAND_ERROR_IS_FATAL ANY
-                )"
+            nanobind_namedtuple_stub_pattern(
+                OUTPUT ${pattern_file}
+                MODULE ${pattern_modules}
+                INSTALL_TIME
                 COMPONENT Lagrange_Python_Runtime
+                PYTHON_PATH ${SKBUILD_PLATLIB_DIR}/lagrange/
             )
             set(pattern_file_args PATTERN_FILE ${pattern_file})
         endif()

--- a/modules/python/CMakeLists.txt
+++ b/modules/python/CMakeLists.txt
@@ -224,6 +224,37 @@ function(lagrange_generate_python_binding_module)
 
         # Generate stubs for python binding within the install location.
         get_target_property(active_modules lagrange_python LAGRANGE_ACTIVE_MODULES)
+
+        # When nanobind_namedtuple is in use, generate a stubgen pattern file at install
+        # time so that classes registered through nbnt::bind_namedtuple are emitted as
+        # canonical typing.NamedTuple blocks. Pattern queries are fully qualified, so a
+        # single shared file is safe to pass to every module's stubgen invocation.
+        set(pattern_file_args "")
+        if(TARGET nanobind_namedtuple)
+            get_target_property(nbnt_source_dir nanobind_namedtuple SOURCE_DIR)
+            set(pattern_file ${CMAKE_CURRENT_BINARY_DIR}/nanobind_namedtuple.pat)
+            set(pattern_module_flags "")
+            foreach(module_name IN ITEMS ${active_modules})
+                get_target_property(python_name lagrange_python LAGRANGE_PYTHON_NAME_${module_name})
+                if(NOT python_name)
+                    set(python_name ${module_name})
+                endif()
+                list(APPEND pattern_module_flags -m lagrange.${python_name})
+            endforeach()
+            list(JOIN pattern_module_flags " " pattern_module_flags)
+            install(CODE "
+                message(STATUS \"Generating nanobind_namedtuple pattern file: ${pattern_file}\")
+                execute_process(
+                    COMMAND \"${CMAKE_COMMAND}\" -E env \"PYTHONPATH=${nbnt_source_dir}/stubgen\"
+                        \"${Python_EXECUTABLE}\" -m nanobind_namedtuple_stubgen
+                        -i \"${SKBUILD_PLATLIB_DIR}/lagrange/\" ${pattern_module_flags} -o \"${pattern_file}\"
+                    COMMAND_ERROR_IS_FATAL ANY
+                )"
+                COMPONENT Lagrange_Python_Runtime
+            )
+            set(pattern_file_args PATTERN_FILE ${pattern_file})
+        endif()
+
         foreach(module_name IN ITEMS ${active_modules})
             get_target_property(python_name lagrange_python LAGRANGE_PYTHON_NAME_${module_name})
             if(NOT python_name)
@@ -239,6 +270,7 @@ function(lagrange_generate_python_binding_module)
                 DEPENDS lagrange_python
                 COMPONENT Lagrange_Python_Runtime
                 PYTHON_PATH ${SKBUILD_PLATLIB_DIR}/lagrange/
+                ${pattern_file_args}
                 VERBOSE
             )
         endforeach()


### PR DESCRIPTION
## Summary

Replaces the hand-rolled `typing.NamedTuple` construction in the bvh Python bindings with an `NB_NAMED_TUPLE` registration from [nanobind_namedtuple](https://github.com/jdumas/nanobind_namedtuple) (header-only, pinned at `5eea9b5` via a new CPM recipe).

- `compute_uv_overlap` now returns the C++ `lagrange::bvh::UVOverlapResult<double, uint32_t>` struct directly; the generated type caster converts it to a `collections.namedtuple` subclass on the Python side.
- Removes the manual field-by-field conversion in the lambda and the `LA_STUB_HINT`/`StubType` stub workaround.
- New `cmake/recipes/external/nanobind_namedtuple.cmake` uses `DOWNLOAD_ONLY ON` and declares the `INTERFACE` target manually (the upstream CMakeLists runs its own `find_package(Python)`/`find_package(nanobind)`, which is redundant inside Lagrange's build).

## Verification

- Local build of `lagrange_python` (macOS arm64, Python 3.12).
- `modules/bvh/python/tests/test_compute_uv_overlap.py` passes unchanged: **21/21**, including `TestResultType` (tuple unpacking, `_asdict`).

## Notes / friction findings

1. ~~**`-Wshadow` conflict**~~ **(fixed upstream, workaround removed in this PR)**: `NB_NAMED_TUPLE_EX` declares a `_nbnt_current_type` alias at both struct scope and inside `fields()`; under Lagrange's `-Wshadow-all -Werror` this fails to compile. Worked around by wrapping the macro invocation in `warnoff.h`/`warnon.h` (same pattern as `binding.h` uses for nanobind includes). Upstream fix would be to drop the redundant inner alias.
2. ~~**Annotations**~~ **(fixed upstream; annotations are now clean type expressions and `typing.get_type_hints()` works)**: `UVOverlapResult.__annotations__` contains nanobind's raw signature markup for STL casters (e.g. `overlapping_pairs: '@collections.abc.Sequence@list@[tuple[int, int]]'`), which breaks `typing.get_type_hints()` at runtime. These markers are meant to be resolved by stubgen.
3. **Stubgen**: Lagrange's `nanobind_add_stub` (stock stubgen, install-time) renders the class as a plain `tuple` subclass with untyped `collections._tuplegetter` fields and leaks the `__nb_named_tuple__`/`__nb_nt_annotations__` dunders. The `compute_uv_overlap` return annotation does correctly point at `UVOverlapResult`. Getting proper `NamedTuple` stubs would require wiring in nanobind_namedtuple's `NamedTupleStubGen` subclass, which `nanobind_add_stub` does not currently support.

